### PR TITLE
feat. impl deprecated annotation inspection

### DIFF
--- a/thrift/src/main/java/com/intellij/plugins/thrift/inspections/ThriftDeprecatedAnnotationInspection.java
+++ b/thrift/src/main/java/com/intellij/plugins/thrift/inspections/ThriftDeprecatedAnnotationInspection.java
@@ -1,0 +1,76 @@
+package com.intellij.plugins.thrift.inspections;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.openapi.editor.colors.CodeInsightColors;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.plugins.thrift.ThriftBundle;
+import com.intellij.plugins.thrift.lang.psi.ThriftField;
+import com.intellij.plugins.thrift.lang.psi.ThriftVisitor;
+import com.intellij.plugins.thrift.util.ThriftPsiUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.ArrayUtil;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ThriftDeprecatedAnnotationInspection extends LocalInspectionTool {
+
+  @Override
+  public @Nls(capitalization = Nls.Capitalization.Sentence) @NotNull String getGroupDisplayName() {
+    return ThriftBundle.message("inspections.group.name");
+  }
+
+  @Override
+  public @Nls(capitalization = Nls.Capitalization.Sentence) @NotNull String getDisplayName() {
+    return ThriftBundle.message("thrift.inspection.deprecated");
+  }
+
+  @Override
+  public boolean isEnabledByDefault() {
+    return true;
+  }
+
+  @Override
+  public @NonNls
+  @NotNull String getShortName() {
+    return "ThriftDeprecatedAnnotation";
+  }
+
+  @Override
+  public ProblemDescriptor @Nullable [] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+    final List<ProblemDescriptor> result = new ArrayList<>();
+    new ThriftVisitor() {
+
+      @Override
+      public void visitField(@NotNull ThriftField o) {
+        if (ThriftPsiUtil.isAnnotatedDeprecated(o)) {
+          ProblemDescriptor problemDescriptor =
+            manager.createProblemDescriptor(
+              o,
+              TextRange.from(0, o.getTextLength()),
+              getDisplayName(),
+              ProblemHighlightType.INFORMATION, // thrift deprecated field cannot be removed, use INFORMATION level to avoid noise
+              isOnTheFly
+            );
+          problemDescriptor.setTextAttributes(CodeInsightColors.DEPRECATED_ATTRIBUTES);
+          result.add(problemDescriptor);
+        }
+      }
+
+      @Override
+      public void visitElement(@NotNull PsiElement element) {
+        super.visitElement(element);
+        element.acceptChildren(this);
+      }
+    }.visitFile(file);
+    return ArrayUtil.toObjectArray(result, ProblemDescriptor.class);
+  }
+}

--- a/thrift/src/main/resources/META-INF/plugin.xml
+++ b/thrift/src/main/resources/META-INF/plugin.xml
@@ -65,6 +65,10 @@
                      key="thrift.inspection.unresolved.include"
                      groupKey="inspections.group.name" enabledByDefault="true"
                      implementationClass="com.intellij.plugins.thrift.inspections.ThriftUnresolvedIncludeInspection"/>
+    <localInspection language="thrift" shortName="ThriftDeprecatedAnnotation" bundle="ThriftBundle"
+                     key="thrift.inspection.deprecated"
+                     groupKey="inspections.group.name" enabledByDefault="true"
+                     implementationClass="com.intellij.plugins.thrift.inspections.ThriftDeprecatedAnnotationInspection"/>
     <localInspection language="thrift" shortName="ThriftTopLevelDeclarationDuplicates" bundle="ThriftBundle"
                      key="thrift.inspection.duplicates.top_level_declaration"
                      groupKey="inspections.group.name" enabledByDefault="true"

--- a/thrift/src/main/resources/ThriftBundle.properties
+++ b/thrift/src/main/resources/ThriftBundle.properties
@@ -1,5 +1,6 @@
 thrift.name=Thrift
 thrift.description=Thrift interface definition
+thrift.inspection.deprecated=Deprecated
 thrift.inspection.duplicates.top_level_declaration=Top level declaration duplicates
 thrift.inspection.duplicates.id=ID duplicates
 thrift.inspection.duplicates.name=Name duplicates


### PR DESCRIPTION
If field is annotated with `deprecated`, draw a ~~strikethrough~~ line on it.

![image](https://user-images.githubusercontent.com/15963765/146506320-c9faec91-61bb-40bd-992e-db2bb1e468e8.png)

Use `ProblemHighlightType.INFORMATION` to avoid the deprecated warning show up. Because thrift deprecation cannot be fixed, this is to avoid noise.

![image](https://user-images.githubusercontent.com/15963765/146509814-a693f810-d1fd-4eaa-9aad-aca6e479518f.png) stays